### PR TITLE
Gnome DEs: set the wallpaper on the dark mode

### DIFF
--- a/superpaper/wallpaper_processing.py
+++ b/superpaper/wallpaper_processing.py
@@ -42,8 +42,10 @@ def running_kde():
 if platform.system() == "Windows":
     from superpaper.wallpaper_windows import set_wallpaper_win
 elif platform.system() == "Linux":
-    # DBus is needed by some DEs to correctly set the wallpaper
-    import dbus
+    # KDE has special needs
+    # if os.environ.get("DESKTOP_SESSION") in ["/usr/share/xsessions/plasma", "plasma"]:
+    if running_kde():
+        import dbus
 elif platform.system() == "Darwin":
     from AppKit import NSScreen, NSWorkspace
     from Foundation import NSURL
@@ -1488,27 +1490,10 @@ def set_wallpaper_linux(outputfile, force=False):
                           "unity", "ubuntu",
                           "pantheon", "budgie-desktop",
                           "pop"]:
-            try:
-                sessionb = dbus.SessionBus()
-                desktop = sessionb.get_object(
-                            "org.freedesktop.portal.Desktop",
-                            "/org/freedesktop/portal/desktop")
-                color_scheme = desktop.Read(
-                                "org.freedesktop.appearance",
-                                "color-scheme",
-                                dbus_interface="org.freedesktop.portal.Settings")
-            except dbus.DBusException:
-                color_scheme = subprocess.run([
-                                "/usr/bin/gsettings", "get",
-                                "org.gnome.desktop.interface", "color-scheme"], 
-                                capture_output=True, universal_newlines=True) \
-                                .stdout.lstrip("\'").rstrip("\'\n")
-            if color_scheme == 1 or color_scheme == "prefer-dark":
-                subprocess.run(["/usr/bin/gsettings", "set",
+            subprocess.run(["/usr/bin/gsettings", "set",
                             "org.gnome.desktop.background", "picture-uri-dark",
                             file])
-            else:
-                subprocess.run(["/usr/bin/gsettings", "set",
+            subprocess.run(["/usr/bin/gsettings", "set",
                             "org.gnome.desktop.background", "picture-uri",
                             file])
         elif desk_env in ["cinnamon"] or "cinnamon" in desk_env.lower():

--- a/superpaper/wallpaper_processing.py
+++ b/superpaper/wallpaper_processing.py
@@ -1503,7 +1503,7 @@ def set_wallpaper_linux(outputfile, force=False):
                                 "org.gnome.desktop.interface", "color-scheme"], 
                                 capture_output=True, universal_newlines=True) \
                                 .stdout.lstrip("\'").rstrip("\'\n")
-            if color_scheme == "1" or color_scheme == 'prefer-dark':
+            if color_scheme == 1 or color_scheme == "prefer-dark":
                 subprocess.run(["/usr/bin/gsettings", "set",
                             "org.gnome.desktop.background", "picture-uri-dark",
                             file])


### PR DESCRIPTION
Following the issue #119, I looked on how to set correctly the wallpaper when the dark mode is applied. While the first try I did was using gsetting to get the current color-scheme, the [dark style preference documentation](https://gitlab.gnome.org/GNOME/Initiatives/-/wikis/Dark-Style-Preference#other) recommends to request its value by the dbus org.freedesktop.portal.Desktop

[Documentation of the dbus variable](https://github.com/flatpak/xdg-desktop-portal/blob/d7a304a00697d7d608821253cd013f3b97ac0fb6/data/org.freedesktop.impl.portal.Settings.xml#L33-L45=)
[Documentation of the gsetting color-scheme variable](https://github.com/GNOME/gsettings-desktop-schemas/blob/master/schemas/org.gnome.desktop.interface.gschema.xml.in#L297=)

Currently tested and work on Fedora 36, Gnome 42.2 Xorg and Wayland. Open to any suggestion, as I didn't had any knowledge on dbus and gsettings.

(Original issue, solution and workaround by [amsteel](https://github.com/amsteel))