### PR TITLE
Update perspective.py

### DIFF
--- a/superpaper/perspective.py
+++ b/superpaper/perspective.py
@@ -438,7 +438,7 @@ def find_coeffs(source_coords, target_coords):
     for s, t in zip(source_coords, target_coords):
         matrix.append([t[0], t[1], 1, 0, 0, 0, -s[0]*t[0], -s[0]*t[1]])
         matrix.append([0, 0, 0, t[0], t[1], 1, -s[1]*t[0], -s[1]*t[1]])
-    A = np.matrix(matrix, dtype=np.float)
+    A = np.matrix(matrix, dtype=np.float64)
     B = np.array(source_coords).reshape(8)
     # res = np.dot(np.linalg.inv(A.T * A) * A.T, B)
     res = np.linalg.solve(A, B)


### PR DESCRIPTION
When setting perspectives, np.float on line 441 is called out as being depreciated. Switched to np.float64 to keep numpy scalar type float. If normal float is needed, use float instead of np.float64.

However, after implementing this fix, I am able to save and apply perspectives in the Perspective Configuration window, but when trying to Apply the perspective in the Superpaper Wallpaper Configuration window, it has an IndexError: list index out of range.

Error called out is:
[superpaper_errors.log](https://github.com/user-attachments/files/17804580/superpaper_errors.log)
